### PR TITLE
Added Negative-Value-Disabling

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Once the extension is correctly loaded and you've inserted the appropriate contr
 5. Custom slide durations may be specified with a custom data-duration
   attribute specified in milliseconds
   (`<div class="slide" data-duration="5000">content</div>`). This attribute
-  overrides the default slide duration.
+  overrides the default slide duration. Negative values for either custom duration
+  or default duration disable automatic advancing for the slides they apply
+  to.
 	
 ## Configuration
 

--- a/automatic/deck.automatic.js
+++ b/automatic/deck.automatic.js
@@ -38,33 +38,36 @@ This module adds automatic control of the deck.
 			if(customDuration){
 			  duration = customDuration;
 			}
-			
-			if (to == slides.length-1) {
-				// setTimeout... called when going to last slide. 
-				// If cycling, set a timeout to go to first slide, else don't set a timeout, and set
-				// state to stopped.
-				if (opts.automatic.cycle) {
-					$[deck].automatic = {
-						timeout: window.setTimeout(function() {
-							$[deck]('go', 0);
-							if (e) e.preventDefault();
-						}, duration)
-					};
-				}
-				else {
-					$(opts.selectors.automaticLink).removeClass(opts.classes.automaticRunning);
-					$(opts.selectors.automaticLink).addClass(opts.classes.automaticStopped);
-				}
-			}
-			else {
-				// Running, not yet on last slide.
-				$[deck].automatic = {
-					timeout: window.setTimeout(function() {
-						$[deck]('next');
-						if (e) e.preventDefault();
-					}, duration)
-				};
-			}
+
+      // If duration is negative, don't set a timeout
+			if(duration >= 0){
+			  if (to == slides.length-1) {
+				  // setTimeout... called when going to last slide. 
+				  // If cycling, set a timeout to go to first slide, else don't set a timeout, and set
+				  // state to stopped.
+				  if (opts.automatic.cycle) {
+					  $[deck].automatic = {
+						  timeout: window.setTimeout(function() {
+							  $[deck]('go', 0);
+							  if (e) e.preventDefault();
+						  }, duration)
+					  };
+				  }
+				  else {
+					  $(opts.selectors.automaticLink).removeClass(opts.classes.automaticRunning);
+					  $(opts.selectors.automaticLink).addClass(opts.classes.automaticStopped);
+				  }
+			  }
+			  else {
+				  // Running, not yet on last slide.
+				  $[deck].automatic = {
+					  timeout: window.setTimeout(function() {
+						  $[deck]('next');
+						  if (e) e.preventDefault();
+					  }, duration)
+				  };
+			  }
+      }
 		}
 	};
 	


### PR DESCRIPTION
A negative value disables automatic advancing of a slide. Making the
default slide duration negative disables automatic advancement unless a
custom value is input for a slide.
